### PR TITLE
6to5 Support

### DIFF
--- a/src/Panel/repl.css
+++ b/src/Panel/repl.css
@@ -3,25 +3,32 @@
   to { transform: rotate(360deg);}
 }
 
-.loading {
-  display: block;
-  width: 24px;
-  height: 24px;
-  position: absolute;
-  left: 50%;
-  top: 50%;
-  margin-left: -12px;
-  margin-top: -12px;
-  border-radius: 50%;
-  border: 3px solid red;
-  border-top-color: transparent;
-  -webkit-animation: spin 1s infinite linear;
-}
-
 body {
   background: #002b36;
   font-size: 100%;
   margin: 0;
+}
+
+hr {
+  border: none;
+  background: #ccc;
+  height: 1px;
+}
+
+.loading {
+  opacity: 0;
+  display: block;
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  border: 3px solid #3b89f3;
+  border-top-color: transparent;
+  -webkit-animation: spin 1s infinite linear;
+  -webkit-transition: all 500ms ease;
+}
+
+.loading.is-active {
+  opacity: 1;
 }
 
 .CodeMirror {
@@ -74,6 +81,7 @@ body {
   top: 0;
   left: 0;
   pointer-events: none;
+  z-index: 100;
 }
 
 .settings__panel {
@@ -89,6 +97,22 @@ body {
   transition: all 200ms ease;
 }
 
+@media (max-width: 500px) {
+  .settings__panel {
+    width: 80%;
+    height: 80%;
+    left: 10%;
+    top: 10%;
+  }
+}
+
+@media (max-height: 400px) {
+  .settings__panel {
+    height: 100%;
+    top: 0;
+  }
+}
+
 .settings.is-active .settings__panel {
   pointer-events: auto;
   opacity: 1;
@@ -100,8 +124,8 @@ body {
   color: #999;
   display: block;
   position: absolute;
-  right: 5px;
-  top: 5px;
+  right: 15px;
+  top: 17px;
   font-size: 18px;
   line-height: 17px;
   padding: 5px 7px;
@@ -117,4 +141,10 @@ body {
 
 .settings__section {
   padding: 0 1em;
+}
+
+.settings__spinner {
+  position: absolute;
+  bottom: 10px;
+  right: 10px;
 }

--- a/src/Panel/repl.css
+++ b/src/Panel/repl.css
@@ -8,22 +8,59 @@ body {
   height: auto;
 }
 
-button {
+.actions {
+  position: fixed;
+  bottom: 20px;
+  right: 20px;
+  z-index: 100;
+}
+
+.execute-script {
   padding: 10px 15px;
   background: #3b89f3;
   border-radius: 10px;
   border: none;
   color: #fff;
-  position: fixed;
-  z-index: 9000;
-  bottom: 20px;
-  right: 20px;
   font-size: 14px;
+  cursor: pointer;
 }
-button:focus {
+.execute-script:focus {
   outline: none;
 }
-button:active {
+.execute-script:active {
   background: #1f72e3;
   padding: 11px 15px 9px 15px;
+}
+
+.open-settings {
+  width: 20px;
+  height: 20px;
+  display: inline-block;
+  vertical-align: middle;
+  margin-right: 10px;
+  padding: 10px;
+  cursor: pointer;
+}
+
+.open-settings path {
+  fill: #586e75;
+}
+
+.settings-panel {
+  background: #fff;
+  position: absolute;
+  width: 40%;
+  height: 40%;
+  left: 30%;
+  top: 30%;
+  opacity: 0;
+  pointer-events: none;
+  transform: scale(0.9) translateY(-20px);
+  transition: all 200ms ease;
+}
+
+.settings-panel.is-active {
+  pointer-events: auto;
+  opacity: 1;
+  transform: scale(1) translateY(0);
 }

--- a/src/Panel/repl.css
+++ b/src/Panel/repl.css
@@ -1,3 +1,23 @@
+@-webkit-keyframes spin {
+  from { transform: rotate(0deg);}
+  to { transform: rotate(360deg);}
+}
+
+.loading {
+  display: block;
+  width: 24px;
+  height: 24px;
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  margin-left: -12px;
+  margin-top: -12px;
+  border-radius: 50%;
+  border: 3px solid red;
+  border-top-color: transparent;
+  -webkit-animation: spin 1s infinite linear;
+}
+
 body {
   background: #002b36;
   font-size: 100%;
@@ -46,7 +66,17 @@ body {
   fill: #586e75;
 }
 
-.settings-panel {
+.settings {
+  perspective: 500px;
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  top: 0;
+  left: 0;
+  pointer-events: none;
+}
+
+.settings__panel {
   background: #fff;
   position: absolute;
   width: 40%;
@@ -55,12 +85,36 @@ body {
   top: 30%;
   opacity: 0;
   pointer-events: none;
-  transform: scale(0.9) translateY(-20px);
+  -webkit-transform: scale(0.9) translateY(40px) rotateX(-20deg);
   transition: all 200ms ease;
 }
 
-.settings-panel.is-active {
+.settings.is-active .settings__panel {
   pointer-events: auto;
   opacity: 1;
-  transform: scale(1) translateY(0);
+  transform: scale(1) translateY(0) rotateX(0deg);
+}
+
+.settings__close-btn {
+  text-decoration: none;
+  color: #999;
+  display: block;
+  position: absolute;
+  right: 5px;
+  top: 5px;
+  font-size: 18px;
+  line-height: 17px;
+  padding: 5px 7px;
+  border-radius: 50%;
+  text-align: center;
+}
+
+.settings__close-btn:hover,
+.settings__close-btn:active {
+  background: #ccc;
+  color: #fff;
+}
+
+.settings__section {
+  padding: 0 1em;
 }

--- a/src/Panel/repl.html
+++ b/src/Panel/repl.html
@@ -7,7 +7,6 @@
 <link rel="stylesheet" href="repl.css">
 
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
-
 </head>
 <body>
 
@@ -17,9 +16,29 @@ Try some of the features supported by Traceur:
 http://kangax.github.io/compat-table/es6/#tr
 ==========================================================*/
 </textarea>
-<button>Run it (<span id="combinationKey">&#8984;</span>&#8617;)</button>
+
+<div class="actions">
+  <svg class="open-settings" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" x="0px" y="0px" viewBox="0 0 512 512" enable-background="new 0 0 512 512" xml:space="preserve"><path id="gearPath" d="M445.52 215h-29.934c-3.903-15-9.922-29.443-17.675-42.547l21.231-21.282c6.438-6.436 6.438-16.895 0-23.331l-34.96-34.972 c-6.434-6.436-16.87-6.442-23.304-0.006l-21.332 21.23C326.443 106.3 312 100.3 297 96.415V66.48 c0-9.101-7.179-16.48-16.28-16.48h-49.44C222.179 50 215 57.4 215 66.48v29.935c-15 3.9-29.443 9.921-42.547 17.7 l-21.282-21.232c-6.436-6.438-16.895-6.438-23.331 0l-34.972 34.96c-6.436 6.434-6.442 16.87-0.006 23.304l21.23 21.3 C106.337 185.6 100.3 200 96.4 215H66.48C57.379 215 50 222.2 50 231.28v49.44c0 9.1 7.4 16.3 16.5 16.28h29.935 c3.9 15 9.9 29.4 17.7 42.547l-21.234 21.282c-6.436 6.434-6.436 16.9 0 23.328l34.96 35 c6.436 6.4 16.9 6.4 23.3 0.007l21.332-21.229C185.557 405.7 200 411.7 215 415.586v29.934 c0 9.1 7.2 16.5 16.3 16.48h49.44c9.102 0 16.28-7.379 16.28-16.48v-29.934c15-3.903 29.443-9.922 42.547-17.675 l21.282 21.231c6.434 6.4 16.9 6.4 23.3 0l34.973-34.96c6.438-6.434 6.444-16.87 0.007-23.304l-21.229-21.332 C405.661 326.4 411.7 312 415.6 297h29.934c9.102 0 16.48-7.179 16.48-16.28v-49.44C462 222.2 454.6 215 445.5 215z M256 338.4c-45.509 0-82.4-36.892-82.4-82.4c0-45.509 36.891-82.4 82.4-82.4c45.509 0 82.4 36.9 82.4 82.4 C338.4 301.5 301.5 338.4 256 338.4z"/></svg>
+  <button class="execute-script">Run it (<span id="combinationKey">&#8984;</span>&#8617;)</button>
+</div>
+
+<div class="settings-panel">
+  <a class="close-settings" href="#">&#10006;</a>
+  <h3>Settings</h3>
+  <hr />
+  <h4>6to5 or Tracuer?</h4>
+  <label>
+    <input type="radio" name="transpiler" value="6to5" checked>
+    6to5
+  </label>
+  <label>
+    <input type="radio" name="transpiler" value="traceur">
+    Traceur
+  </label>
+</div>
 
 <script type="text/javascript" src="../node_modules/traceur/bin/traceur.js"></script>
+<script type="text/javascript" src="../node_modules/6to5/browser.js"></script>
 <script type="text/javascript" src="repl.js"></script>
 
 <script src="codemirror/codemirror.js"></script>

--- a/src/Panel/repl.html
+++ b/src/Panel/repl.html
@@ -30,11 +30,11 @@ http://kangax.github.io/compat-table/es6/#tr
     </div>
     <hr />
     <div class="settings__section">
-      <div class="loading"></div>
+      <div class="loading settings__spinner"></div>
       <h4>6to5 or Tracuer?</h4>
       <div>
         <label>
-          <input type="radio" name="transpiler" value="6to5" checked>
+          <input type="radio" name="transpiler" value="6to5">
           6to5
         </label>
       </div>

--- a/src/Panel/repl.html
+++ b/src/Panel/repl.html
@@ -22,19 +22,30 @@ http://kangax.github.io/compat-table/es6/#tr
   <button class="execute-script">Run it (<span id="combinationKey">&#8984;</span>&#8617;)</button>
 </div>
 
-<div class="settings-panel">
-  <a class="close-settings" href="#">&#10006;</a>
-  <h3>Settings</h3>
-  <hr />
-  <h4>6to5 or Tracuer?</h4>
-  <label>
-    <input type="radio" name="transpiler" value="6to5" checked>
-    6to5
-  </label>
-  <label>
-    <input type="radio" name="transpiler" value="traceur">
-    Traceur
-  </label>
+<div class="settings">
+  <div class="settings__panel">
+    <a class="settings__close-btn" href="#">&#10006;</a>
+    <div class="settings__section">
+      <h3>Settings</h3>
+    </div>
+    <hr />
+    <div class="settings__section">
+      <div class="loading"></div>
+      <h4>6to5 or Tracuer?</h4>
+      <div>
+        <label>
+          <input type="radio" name="transpiler" value="6to5" checked>
+          6to5
+        </label>
+      </div>
+      <div>
+        <label>
+          <input type="radio" name="transpiler" value="traceur">
+          Traceur
+        </label>
+      </div>
+    </div>
+  </div>
 </div>
 
 <script type="text/javascript" src="../node_modules/traceur/bin/traceur.js"></script>

--- a/src/Panel/repl.js
+++ b/src/Panel/repl.js
@@ -102,7 +102,7 @@ function Repl() {
 
 Repl.prototype.insertRuntime = function() {
   var transpiler = this.settings.data.transpiler;
-  if(transpiler in this.RUNTIME_PATHS) {
+  if(this.RUNTIME_PATHS[transpiler]) {
     var str =
       "if(!document.querySelector('#"+transpiler+"')) {" +
         "var st = document.createElement('script');" +

--- a/src/Panel/repl.js
+++ b/src/Panel/repl.js
@@ -1,52 +1,98 @@
-document.addEventListener('DOMContentLoaded', function(){
-  // var str = "var st = document.createElement('script'); st.src = '"+chrome.extension.getURL('node_modules/traceur/bin/traceur-runtime.js')+"'; (document.head||document.documentElement).appendChild(st);"
-  // chrome.devtools.inspectedWindow.eval(str)
+/*----------------------------------
+  Settings and storage
+ ---------------------------------*/
+function Settings() {
+  var _this = this;
+  var DEFAULTS = this.data = {
+    transpiler: '6to5'
+  }
 
-  var editor = CodeMirror.fromTextArea(document.querySelector("textarea"), {
+  // Check for latest settings
+  this.get(function(data) {
+    // If there's no data stored, store the defaults
+    if(typeof data === undefined || !data.hasOwnProperty('transpiler')) {
+      _this.set(DEFAULTS);
+    }
+    else {
+      _this.data = data;
+    }
+  });
+}
+
+Settings.prototype.get = function(cb) {
+  chrome.storage.sync.get('settings', cb);
+}
+
+Settings.prototype.set = function(settings, cb) {
+  cb = cb || function(){}
+  chrome.storage.sync.set({settings: settings}, cb);
+}
+
+
+/*----------------------------------
+  The Repl interface / app
+ ---------------------------------*/
+var combinationKey = 'metaKey';
+function Repl() {
+  this.RUNTIME_PATHS = {
+    'traceur': 'node_modules/traceur/bin/traceur-runtime.js'
+  }
+
+  document.addEventListener('DOMContentLoaded', this.onDomReady.bind(this));
+  this.addEventListeners.call(this);
+  this.settings = new Settings();
+}
+
+Repl.prototype.onDomReady = function() {
+  if(this.settings.data.transpiler in this.RUNTIME_PATHS) {
+    var str = "var st = document.createElement('script'); st.src = '"+chrome.extension.getURL(this.RUNTIME_PATHS[this.settings.data.transpiler])+"'; (document.head||document.documentElement).appendChild(st);"
+    chrome.devtools.inspectedWindow.eval(str)
+  }
+
+  this.editor = CodeMirror.fromTextArea(document.querySelector("textarea"), {
     lineNumbers: true,
     matchBrackets: true,
     continueComments: "Enter",
     extraKeys: {"Ctrl-Q": "toggleComment"},
     tabSize: 2,
-    autoCloseBrackets: true
+    autoCloseBrackets: true,
+    theme: 'solarized dark'
   });
 
-  editor.setOption('theme', 'solarized dark');
-
-  var deliverContent = function(content){
-    // traceur.options.experimental = true;
-    try {
-      var es5 = to5.transform(content);
-      // var es5 = traceur.Compiler.script(content);
-      chrome.devtools.inspectedWindow.eval(es5.code, function(result, exceptionInfo) {
-        if(typeof exceptionInfo !== 'undefined' && exceptionInfo.hasOwnProperty('isException'))
-          logError(exceptionInfo.value);
-      });
-    }
-    catch (e) {
-      logError(e);
-    }
-  }
-
-  var combinationKey = 'metaKey';
   chrome.runtime.sendMessage('platformInfo', function(info) {
     if (info.os !== 'mac') {
       combinationKey = 'ctrlKey';
       document.getElementById('combinationKey').textContent = 'Ctrl';
     }
   });
+}
 
-  document.onkeydown = function(e){
-    if(e[combinationKey] && e.which == 13){
-      deliverContent(editor.getValue());
+Repl.prototype.deliverContent = function(content){
+  if(this.settings.data.transpiler === 'traceur')
+    traceur.options.experimental = true;
+
+  try {
+    if(this.settings.data.transpiler === 'traceur') {
+      var es5 = traceur.Compiler.script(content);
     }
-    if(e[combinationKey] && e.which == 48) {
-      location.reload();
+    else if(this.settings.data.transpiler === '6to5') {
+      var es5 = to5.transform(content).code;
     }
+    chrome.devtools.inspectedWindow.eval(es5, function(result, exceptionInfo) {
+      if(typeof exceptionInfo !== 'undefined' && exceptionInfo.hasOwnProperty('isException'))
+        logError(exceptionInfo.value);
+    });
   }
+  catch (e) {
+    logError(e);
+  }
+}
+
+Repl.prototype.addEventListeners = function() {
+  var _this = this;
 
   document.querySelector('.execute-script').addEventListener('click', function(){
-    deliverContent(editor.getValue());
+    _this.deliverContent(_this.editor.getValue());
   });
 
   document.querySelector('.open-settings').addEventListener('click', function() {
@@ -56,7 +102,19 @@ document.addEventListener('DOMContentLoaded', function(){
   document.querySelector('.close-settings').addEventListener('click', function() {
     document.querySelector('.settings-panel').classList.remove('is-active');
   });
-});
+
+  document.onkeydown = function(e){
+    if(e[combinationKey] && e.which == 13){
+      _this.deliverContent(_this.editor.getValue());
+    }
+    if(e[combinationKey] && e.which == 48) {
+      location.reload();
+    }
+  }
+}
+
+// Instantiate the object
+var repl = new Repl();
 
 function logError(err) {
   chrome.devtools.inspectedWindow.eval("console.error(\"" + err + "\");");

--- a/src/Panel/repl.js
+++ b/src/Panel/repl.js
@@ -103,6 +103,12 @@ Repl.prototype.addEventListeners = function() {
     document.querySelector('.settings-panel').classList.remove('is-active');
   });
 
+  [].forEach.call(document.querySelectorAll('input[name="transpiler"]'), function (el) {
+    el.addEventListener('click', function(e) {
+      _this.settings.set({ transpiler: e.target.value });
+    });
+  });
+
   document.onkeydown = function(e){
     if(e[combinationKey] && e.which == 13){
       _this.deliverContent(_this.editor.getValue());

--- a/src/Panel/repl.js
+++ b/src/Panel/repl.js
@@ -1,6 +1,6 @@
 document.addEventListener('DOMContentLoaded', function(){
-  var str = "var st = document.createElement('script'); st.src = '"+chrome.extension.getURL('node_modules/traceur/bin/traceur-runtime.js')+"'; (document.head||document.documentElement).appendChild(st);"
-  chrome.devtools.inspectedWindow.eval(str)
+  // var str = "var st = document.createElement('script'); st.src = '"+chrome.extension.getURL('node_modules/traceur/bin/traceur-runtime.js')+"'; (document.head||document.documentElement).appendChild(st);"
+  // chrome.devtools.inspectedWindow.eval(str)
 
   var editor = CodeMirror.fromTextArea(document.querySelector("textarea"), {
     lineNumbers: true,
@@ -14,10 +14,11 @@ document.addEventListener('DOMContentLoaded', function(){
   editor.setOption('theme', 'solarized dark');
 
   var deliverContent = function(content){
-    traceur.options.experimental = true;
+    // traceur.options.experimental = true;
     try {
-      var es5 = traceur.Compiler.script(content);
-      chrome.devtools.inspectedWindow.eval(es5, function(result, exceptionInfo) {
+      var es5 = to5.transform(content);
+      // var es5 = traceur.Compiler.script(content);
+      chrome.devtools.inspectedWindow.eval(es5.code, function(result, exceptionInfo) {
         if(typeof exceptionInfo !== 'undefined' && exceptionInfo.hasOwnProperty('isException'))
           logError(exceptionInfo.value);
       });
@@ -39,10 +40,21 @@ document.addEventListener('DOMContentLoaded', function(){
     if(e[combinationKey] && e.which == 13){
       deliverContent(editor.getValue());
     }
+    if(e[combinationKey] && e.which == 48) {
+      location.reload();
+    }
   }
 
-  document.querySelector('button').addEventListener('click', function(){
+  document.querySelector('.execute-script').addEventListener('click', function(){
     deliverContent(editor.getValue());
+  });
+
+  document.querySelector('.open-settings').addEventListener('click', function() {
+    document.querySelector('.settings-panel').classList.toggle('is-active');
+  });
+
+  document.querySelector('.close-settings').addEventListener('click', function() {
+    document.querySelector('.settings-panel').classList.remove('is-active');
   });
 });
 

--- a/src/background.js
+++ b/src/background.js
@@ -1,8 +1,13 @@
 chrome.runtime.onMessage.addListener(function(request, sender, sendResponse) {
-  if (request === 'platformInfo') {
+  if (request.name === 'platformInfo') {
     chrome.runtime.getPlatformInfo(function(info) {
       sendResponse(info);
     });
     return true; // indicates sendResponse will be called asynchronously
+  } else if(request.name === 'getSettings') {
+    sendResponse(JSON.parse(localStorage.getItem('settings')));
+  } else if(request.name === 'setSettings') {
+    localStorage.setItem('settings', JSON.stringify(request.value));
+    sendResponse(localStorage.getItem('settings'));
   }
 });

--- a/src/package.json
+++ b/src/package.json
@@ -13,6 +13,7 @@
   },
   "homepage": "https://github.com/richgilbank/ES6-Repl-Chrome-Extension",
   "dependencies": {
-    "traceur": "0.0.72"
+    "traceur": "0.0.72",
+    "6to5": "3.3.12"
   }
 }


### PR DESCRIPTION
Adds 6to5 support to the extension and the ability to switch which tool to use through a settings menu. Much more is needed here, but hopefully this will serve as a good starting point. Anyone mind trying it out? @hemanth @darcyclarke @tessalt
__The diff's not going to be of much use; better to just look through the files on the branch.__

Everything in `src/Panel/repl.js` clearly needs to be broken out into separate files and we definitely have a need for a CSS preprocessor now; I think @hemanth and @tessalt both expressed interest in bringing gulp or similar in...I'll create an issue for further discussion. 

Closes https://github.com/richgilbank/ES6-Repl-Chrome-Extension/issues/17