### PR TITLE
Separate transformers

### DIFF
--- a/src/Panel/events.js
+++ b/src/Panel/events.js
@@ -4,14 +4,23 @@
 var Events = function() {};
 Events.prototype = {
   _events: {},
-  on: function(event, callback) {
+
+  on: function(event, callback, context) {
+    context = context || this;
     this._events[event] = this._events[event] || [];
-    this._events[event].push(callback);
+    this._events[event].push({
+      callback: callback,
+      context: context
+    });
   },
+
   trigger: function(event) {
     if(!this._events.hasOwnProperty(event)) return;
+    var responses = [];
     for(handler of this._events[event]) {
-      handler.apply(this, Array.prototype.slice.call(arguments, 1));
+      var args = Array.prototype.slice.call(arguments, 1);
+      responses.push(handler.callback.apply(handler.context, args));
     }
+    return responses;
   }
 }

--- a/src/Panel/index.js
+++ b/src/Panel/index.js
@@ -1,0 +1,1 @@
+window.bus = new Events();

--- a/src/Panel/repl.html
+++ b/src/Panel/repl.html
@@ -84,8 +84,12 @@ http://kangax.github.io/compat-table/es6/#tr
 <script src="../node_modules/6to5/browser.js"></script>
 
 <script src="events.js"></script>
+<script src="index.js"></script>
 <script src="settings.js"></script>
 <script src="util.js"></script>
+<script src="transformers/transformer.js"></script>
+<script src="transformers/traceur.js"></script>
+<script src="transformers/babel.js"></script>
 <script src="repl.js"></script>
 
 <script src="codemirror/codemirror.js"></script>

--- a/src/Panel/repl.html
+++ b/src/Panel/repl.html
@@ -43,19 +43,8 @@ http://kangax.github.io/compat-table/es6/#tr
     <div class="settings__section">
       <div class="loading settings__spinner"></div>
 
-      <h4>6to5 or Tracuer?</h4>
-      <div>
-        <label>
-          <input type="radio" name="transformer" value="to5">
-          6to5
-        </label>
-      </div>
-      <div>
-        <label>
-          <input type="radio" name="transformer" value="traceur">
-          Traceur
-        </label>
-      </div>
+      <h4>Transformer</h4>
+      <div class="transformer-options"></div>
 
       <h4>Theme</h4>
       <div>

--- a/src/Panel/repl.html
+++ b/src/Panel/repl.html
@@ -46,13 +46,13 @@ http://kangax.github.io/compat-table/es6/#tr
       <h4>6to5 or Tracuer?</h4>
       <div>
         <label>
-          <input type="radio" name="transpiler" value="to5">
+          <input type="radio" name="transformer" value="to5">
           6to5
         </label>
       </div>
       <div>
         <label>
-          <input type="radio" name="transpiler" value="traceur">
+          <input type="radio" name="transformer" value="traceur">
           Traceur
         </label>
       </div>

--- a/src/Panel/repl.js
+++ b/src/Panel/repl.js
@@ -5,10 +5,10 @@ var combinationKey = 'metaKey';
 
 function Repl() {
 
-  var registered = bus.trigger('transpilers:register');
-  this.transpilers = {};
+  var registered = bus.trigger('transformers:register');
+  this.transformers = {};
   registered.forEach(function(v) {
-    this.transpilers[v.handle] = v;
+    this.transformers[v.handle] = v;
   }, this);
 
   this.settings = new Settings(this);
@@ -23,7 +23,6 @@ function Repl() {
 }
 
 Repl.prototype.onDomReady = function() {
-  var _this = this;
   this.addEventListeners.call(this);
 
   this.width = window.innerWidth;
@@ -47,10 +46,11 @@ Repl.prototype.onDomReady = function() {
 }
 
 Repl.prototype.deliverContent = function(content){
-  this.settings.data.transpiler.beforeTransform();
+  var transformer = this.transformers[this.settings.data.transformer];
+  transformer.beforeTransform();
 
   try {
-    var es5 = this.settings.data.transpiler.transform(content);
+    var es5 = transformer.transform(content);
 
     if (this.output)
       this.output.setValue(es5);
@@ -123,17 +123,11 @@ Repl.prototype.addEventListeners = function() {
   };
 
   window.addEventListener('resize', debounce(this.onWindowResize.bind(this)), 200);
-
   document.getElementById('resize').addEventListener('mousedown', debounce(this.onReizeMousedown.bind(this)), 200);
 
   bus.on('settings:changed:theme', function(theme) {
     this.editor.setOption('theme', theme);
     if(this.output) this.output.setOption('theme', theme);
-  }, this);
-
-  bus.on('settings:changed:transpiler', function(transpilerHandle) {
-    this.settings.data.transpiler = this.transpilers[transpilerHandle];
-    this.settings.data.transpiler.insertRuntime();
   }, this);
 }
 

--- a/src/Panel/repl.js
+++ b/src/Panel/repl.js
@@ -2,13 +2,15 @@
   The Repl interface / app
  ---------------------------------*/
 var combinationKey = 'metaKey';
-function Repl() {
-  this.RUNTIME_PATHS = {
-    'traceur': 'node_modules/traceur/bin/traceur-runtime.js',
-    'to5': 'node_modules/6to5/browser-polyfill.js'
-  }
 
-  this.bus = new Events();
+function Repl() {
+
+  var registered = bus.trigger('transpilers:register');
+  this.transpilers = {};
+  registered.forEach(function(v) {
+    this.transpilers[v.handle] = v;
+  }, this);
+
   this.settings = new Settings(this);
 
   this.DOM = {
@@ -18,20 +20,6 @@ function Repl() {
   }
 
   document.addEventListener('DOMContentLoaded', this.onDomReady.bind(this));
-}
-
-Repl.prototype.insertRuntime = function() {
-  var transpiler = this.settings.data.transpiler;
-  if(this.RUNTIME_PATHS[transpiler]) {
-    var str =
-      "if(!document.querySelector('#"+transpiler+"')) {" +
-        "var st = document.createElement('script');" +
-        "st.id='"+ transpiler +"';" +
-        "st.src = '"+chrome.extension.getURL(this.RUNTIME_PATHS[transpiler])+"';" +
-        "(document.head||document.documentElement).appendChild(st);" +
-      "}";
-    chrome.devtools.inspectedWindow.eval(str)
-  }
 }
 
 Repl.prototype.onDomReady = function() {
@@ -59,16 +47,10 @@ Repl.prototype.onDomReady = function() {
 }
 
 Repl.prototype.deliverContent = function(content){
-  if(this.settings.data.transpiler === 'traceur')
-    traceur.options.experimental = true;
+  this.settings.data.transpiler.beforeTransform();
 
   try {
-    if(this.settings.data.transpiler === 'traceur') {
-      var es5 = traceur.Compiler.script(content);
-    }
-    if(this.settings.data.transpiler === 'to5') {
-      var es5 = to5.transform(content).code;
-    }
+    var es5 = this.settings.data.transpiler.transform(content);
 
     if (this.output)
       this.output.setValue(es5);
@@ -144,15 +126,16 @@ Repl.prototype.addEventListeners = function() {
 
   document.getElementById('resize').addEventListener('mousedown', debounce(this.onReizeMousedown.bind(this)), 200);
 
-  this.bus.on('settings:changed:theme', function(theme) {
-    _this.editor.setOption('theme', theme);
-    if(_this.output) _this.output.setOption('theme', theme);
-  });
+  bus.on('settings:changed:theme', function(theme) {
+    this.editor.setOption('theme', theme);
+    if(this.output) this.output.setOption('theme', theme);
+  }, this);
 
-  this.bus.on('settings:changed:transpiler', function(transpiler) {
-    _this.insertRuntime();
-  });
+  bus.on('settings:changed:transpiler', function(transpilerHandle) {
+    this.settings.data.transpiler = this.transpilers[transpilerHandle];
+    this.settings.data.transpiler.insertRuntime();
+  }, this);
 }
 
 // Instantiate the object
-var repl = new Repl();
+window.repl = new Repl();

--- a/src/Panel/settings.js
+++ b/src/Panel/settings.js
@@ -29,11 +29,11 @@ Settings.prototype.onDomReady = function() {
       _this.data = data;
       _this.setFormDefaults(data);
       for(key in data) {
-        _this.repl.bus.trigger('settings:changed:' + key, data[key]);
+        bus.trigger('settings:changed:' + key, data[key]);
       }
     }
 
-    _this.repl.insertRuntime();
+    bus.trigger('settings:changed:transpiler', _this.data.transpiler.handle);
   });
 
   document.querySelector('.open-settings').addEventListener('click', function() {
@@ -102,7 +102,7 @@ Settings.prototype.set = function(settings, cb) {
       cb();
 
     for(key in settings) {
-      _this.repl.bus.trigger('settings:changed:' + key, settings[key]);
+      bus.trigger('settings:changed:' + key, settings[key]);
     }
   });
 }

--- a/src/Panel/settings.js
+++ b/src/Panel/settings.js
@@ -33,6 +33,7 @@ Settings.prototype.onDomReady = function() {
       }
     }
 
+    document.querySelector('.transformer-options').innerHTML = _this.transformerOptionTemplate(this.repl.transformers);
     bus.trigger('settings:changed:transformer', _this.data.transformer.handle);
   });
 
@@ -44,10 +45,9 @@ Settings.prototype.onDomReady = function() {
     document.querySelector('.settings').classList.remove('is-active');
   });
 
-  [].forEach.call(document.querySelectorAll('input[name="transformer"]'), function (el) {
-    el.addEventListener('click', function(e) {
+  document.querySelector('.transformer-options').addEventListener('click', function(e) {
+    if(e.target.name === 'transformer')
       _this.set({ transformer: e.target.value });
-    });
   });
 
   [].forEach.call(document.querySelectorAll('input[name="theme"]'), function (el) {
@@ -57,8 +57,22 @@ Settings.prototype.onDomReady = function() {
   });
 }
 
+Settings.prototype.transformerOptionTemplate = function(transformers) {
+  var template = '';
+  for(var i in transformers) {
+    var t = transformers[i];
+    template +=
+      '<div>' +
+        '<label>' +
+          '<input type="radio" name="transformer" value="' + t.handle + '"' + (t._active ? ' checked' : '') + '>' +
+          t.name +
+        '</label>' +
+      '</div>'
+  }
+  return template;
+}
+
 Settings.prototype.setFormDefaults = function() {
-  document.querySelector('[name="transformer"][value="' + this.data.transformer + '"]').checked = true;
   document.querySelector('[name="theme"][value="' + this.data.theme + '"]').checked = true;
 }
 

--- a/src/Panel/settings.js
+++ b/src/Panel/settings.js
@@ -6,7 +6,7 @@ function Settings(repl) {
   this.domReady = false;
   this.repl = repl;
   this.DEFAULTS = this.data = {
-    transpiler: 'to5',
+    transformer: 'to5',
     theme: 'solarized dark'
   }
 
@@ -20,7 +20,7 @@ Settings.prototype.onDomReady = function() {
   // Check for latest settings
   this.get(function(data) {
     // If there's no data stored, store the defaults
-    if(typeof data === undefined || !data.hasOwnProperty('transpiler')) {
+    if(typeof data === undefined || !data.hasOwnProperty('transformer')) {
       _this.set(_this.DEFAULTS, function() {
         _this.setFormDefaults(_this.data);
       });
@@ -33,7 +33,7 @@ Settings.prototype.onDomReady = function() {
       }
     }
 
-    bus.trigger('settings:changed:transpiler', _this.data.transpiler.handle);
+    bus.trigger('settings:changed:transformer', _this.data.transformer.handle);
   });
 
   document.querySelector('.open-settings').addEventListener('click', function() {
@@ -44,9 +44,9 @@ Settings.prototype.onDomReady = function() {
     document.querySelector('.settings').classList.remove('is-active');
   });
 
-  [].forEach.call(document.querySelectorAll('input[name="transpiler"]'), function (el) {
+  [].forEach.call(document.querySelectorAll('input[name="transformer"]'), function (el) {
     el.addEventListener('click', function(e) {
-      _this.set({ transpiler: e.target.value });
+      _this.set({ transformer: e.target.value });
     });
   });
 
@@ -58,7 +58,7 @@ Settings.prototype.onDomReady = function() {
 }
 
 Settings.prototype.setFormDefaults = function() {
-  document.querySelector('[name="transpiler"][value="' + this.data.transpiler + '"]').checked = true;
+  document.querySelector('[name="transformer"][value="' + this.data.transformer + '"]').checked = true;
   document.querySelector('[name="theme"][value="' + this.data.theme + '"]').checked = true;
 }
 

--- a/src/Panel/transformers/babel.js
+++ b/src/Panel/transformers/babel.js
@@ -1,6 +1,7 @@
 function Babel() {
   Transformer.call(this);
 
+  this.name = 'Babel';
   this.handle = 'to5';
   this.runtimePath = 'node_modules/6to5/browser-polyfill.js';
 }

--- a/src/Panel/transformers/babel.js
+++ b/src/Panel/transformers/babel.js
@@ -1,0 +1,16 @@
+function Babel() {
+  Transformer.call(this);
+
+  this.handle = 'to5';
+  this.runtimePath = 'node_modules/6to5/browser-polyfill.js';
+}
+
+// Inherit from Transformer
+Babel.prototype = Object.create(Transformer.prototype);
+Babel.prototype.constructor = Babel;
+
+Babel.prototype.transform = function(input) {
+  return to5.transform(input).code;
+}
+
+var babelTransformer = new Babel();

--- a/src/Panel/transformers/traceur.js
+++ b/src/Panel/transformers/traceur.js
@@ -1,0 +1,21 @@
+function Traceur() {
+  Transformer.call(this);
+
+  this.handle = 'traceur';
+  this.runtimePath = 'node_modules/traceur/bin/traceur-runtime.js';
+}
+
+// Inherit from Transformer
+Traceur.prototype = Object.create(Transformer.prototype);
+Traceur.prototype.constructor = Traceur;
+
+Traceur.prototype.beforeTransform = function() {
+  debugger
+  traceur.options.experimental = true;
+}
+
+Traceur.prototype.transform = function(input) {
+  return traceur.Compiler.script(input);
+}
+
+var traceurTransformer = new Traceur();

--- a/src/Panel/transformers/traceur.js
+++ b/src/Panel/transformers/traceur.js
@@ -1,6 +1,7 @@
 function Traceur() {
   Transformer.call(this);
 
+  this.name = 'Traceur';
   this.handle = 'traceur';
   this.runtimePath = 'node_modules/traceur/bin/traceur-runtime.js';
 }
@@ -10,7 +11,6 @@ Traceur.prototype = Object.create(Transformer.prototype);
 Traceur.prototype.constructor = Traceur;
 
 Traceur.prototype.beforeTransform = function() {
-  debugger
   traceur.options.experimental = true;
 }
 

--- a/src/Panel/transformers/transformer.js
+++ b/src/Panel/transformers/transformer.js
@@ -1,17 +1,18 @@
 function Transformer() {
   bus.on('transformers:register', this.registerSelf, this);
-  bus.on('settings:changed:transformer', this.insertRuntime, this);
+  bus.on('settings:changed:transformer', this.onTransformerChange, this);
 }
 
 // Attributes to override on the subclass
 Transformer.prototype = {
   // Required
+  name: false,
   handle: false,
   runtimePath: false,
   transform: function(input) { return ''; },
 
   // Optional
-  beforeTransform: function() {}
+  beforeTransform: function() {},
 
   // Internal
   _active: false

--- a/src/Panel/transformers/transformer.js
+++ b/src/Panel/transformers/transformer.js
@@ -1,0 +1,31 @@
+function Transformer() {
+  bus.on('transpilers:register', this.registerSelf, this);
+  bus.on('settings:changed:transpiler', this.insertRuntime, this);
+}
+
+// Attributes to override on the subclass
+Transformer.prototype = {
+  // Required
+  handle: false,
+  runtimePath: false,
+  transform: function(input) { return ''; },
+
+  // Optional
+  beforeTransform: function() {}
+}
+
+Transformer.prototype.insertRuntime = function() {
+  if(!this.runtimePath) return false;
+  var str =
+    "if(!document.querySelector('#" + this.handle + "')) {" +
+      "var st = document.createElement('script');" +
+      "st.id='" + this.handle + "';" +
+      "st.src = '" + chrome.extension.getURL(this.runtimePath) + "';" +
+      "document.head.appendChild(st);" +
+    "}";
+  chrome.devtools.inspectedWindow.eval(str)
+}
+
+Transformer.prototype.registerSelf = function() {
+  return this;
+}

--- a/src/Panel/transformers/transformer.js
+++ b/src/Panel/transformers/transformer.js
@@ -1,6 +1,6 @@
 function Transformer() {
-  bus.on('transpilers:register', this.registerSelf, this);
-  bus.on('settings:changed:transpiler', this.insertRuntime, this);
+  bus.on('transformers:register', this.registerSelf, this);
+  bus.on('settings:changed:transformer', this.insertRuntime, this);
 }
 
 // Attributes to override on the subclass
@@ -12,6 +12,9 @@ Transformer.prototype = {
 
   // Optional
   beforeTransform: function() {}
+
+  // Internal
+  _active: false
 }
 
 Transformer.prototype.insertRuntime = function() {
@@ -24,6 +27,15 @@ Transformer.prototype.insertRuntime = function() {
       "document.head.appendChild(st);" +
     "}";
   chrome.devtools.inspectedWindow.eval(str)
+}
+
+Transformer.prototype.onTransformerChange = function(newTransformer) {
+  if(this._active && newTransformer !== this.handle) {
+    // TODO: Remove runtime
+  } else if(newTransformer === this.handle) {
+    this.insertRuntime();
+    this._active = true;
+  }
 }
 
 Transformer.prototype.registerSelf = function() {

--- a/src/gulpfile.js
+++ b/src/gulpfile.js
@@ -11,7 +11,7 @@ var FILES = {
     '!package.json',
     '!gulpfile.js'
   ],
-  watch: ['panel/*.{js,css,html}'],
+  watch: ['panel/**/*.{js,css,html}'],
   panel: 'panel/repl.html',
   dist: '../dist/',
   distPanel: '../dist/panel/',


### PR DESCRIPTION
Renaming transpilers to transformers because it's more generic and allows for the addition of future tooling ideas. Also breaks them out to their own concerns so they can be added with trivial effort.